### PR TITLE
進捗率計算メソッドの追加

### DIFF
--- a/app/models/concerns/common_module.rb
+++ b/app/models/concerns/common_module.rb
@@ -1,0 +1,17 @@
+module CommonModule
+  extend ActiveSupport::Concern
+
+  #呼び出しインスタンスがGoalの場合とStageの場合で条件分岐
+  #Rubyでは整数同士の除算で出る小数は切り捨てられるため、float型へ変換して計算
+  def progress_rate
+    if self.instance_of?(Goal)
+      return nil if self.stages.count == 0
+      rate = self.stages.where(status: true).count / self.stages.count.to_f
+    else
+      return nil if self.todos.count == 0
+      rate = self.todos.where(status: true).count / self.todos.count.to_f
+    end
+    (rate*100).to_i.round
+  end
+
+end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -1,4 +1,5 @@
 class Goal < ApplicationRecord
+  include CommonModule
   enum status: { active: 0, pending: 1, done: 2, fail: 3 }
   validates :title, presence: true
 

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -1,4 +1,5 @@
 class Stage < ApplicationRecord
+  include CommonModule
   belongs_to :goal
   has_many :todos
   validates :title, presence: true


### PR DESCRIPTION
#what
共通の処理を行うためのmoduleを作成。
Goal, Stageの進捗率を求めるメソッドを作成した。

#why
進捗度合いが数値としてユーザーに認識されることで、ユーザーの目標に対する意識向上と、目標達成までのペース配分を考える手助けとなるため。